### PR TITLE
complete() never gets called in modalmanager if there is a fast transition

### DIFF
--- a/js/bootstrap-modalmanager.js
+++ b/js/bootstrap-modalmanager.js
@@ -93,7 +93,7 @@
 							modal.$element.triggerHandler('shown');
 						};
 
-						if (transition && modal.$element.is('hidden')) {
+						if (transition && modal.$element.is(':hidden')) {
 							modal.$element.one($.support.transition.end, complete);
 						} else {
 							complete();


### PR DESCRIPTION
### Description

`complete()` in `appendModal` doesn't get fired after the modal appears when transitions are enabled and the transition finishes before the JS reaches that point. It does however fire `complete()` and therefore `setFocus` as soon as a user triggers any webkit animation (i.e. textbox highlight on focus in bootstrap), then it re-focuses everything again causing weird input focussing bugs. Since it is a .one binding, it doesn't happen over and over -- only annoyingly makes you select an input twice or selects the first element when you click on the second one.
### The Fix

If the transition is already complete (element is shown) then fire complete immediately.
