### PR TITLE
Namespacing of events

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -54,7 +54,7 @@
 		},
 
 		show: function () {
-			var e = $.Event('show');
+			var e = $.Event('show.modal');
 
 			if (this.isShown) return;
 
@@ -72,7 +72,7 @@
 		hide: function (e) {
 			e && e.preventDefault();
 
-			e = $.Event('hide');
+			e = $.Event('hide.modal');
 
 			this.$element.triggerHandler(e);
 
@@ -204,7 +204,7 @@
 		hideModal: function () {
 			this.$element
 				.hide()
-				.triggerHandler('hidden');
+				.triggerHandler('hidden.modal');
 
 			var prop = this.options.height ? 'height' : 'max-height';
 			var value = this.options.height || this.options.maxHeight;
@@ -289,7 +289,7 @@
 
 
 		destroy: function () {
-			var e = $.Event('destroy');
+			var e = $.Event('destroy.modal');
 			this.$element.triggerHandler(e);
 			if (e.isDefaultPrevented()) return;
 
@@ -365,7 +365,7 @@
 			e.preventDefault();
 			$target
 				.modal(option)
-				.one('hide', function () {
+				.one('hide.modal', function () {
 					$this.focus();
 				})
 		});

--- a/js/bootstrap-modalmanager.js
+++ b/js/bootstrap-modalmanager.js
@@ -61,7 +61,7 @@
 
 			var that = this;
 
-			modal.$element.on('show.modalmanager', targetIsSelf(function (e) {
+			modal.$element.on('show.modal.modalmanager', targetIsSelf(function (e) {
 
 				var showModal = function(){
 					modal.isShown = true;
@@ -96,7 +96,7 @@
 
 						var complete = function () {
 							that.setFocus();
-							modal.$element.triggerHandler('shown');
+							modal.$element.triggerHandler('shown.modal');
 						};
 
 						transition ?
@@ -110,7 +110,7 @@
 					showModal();
 			}));
 
-			modal.$element.on('hidden.modalmanager', targetIsSelf(function (e) {
+			modal.$element.on('hidden.modal.modalmanager', targetIsSelf(function (e) {
 
 				that.backdrop(modal);
 
@@ -124,7 +124,7 @@
 
 			}));
 
-			modal.$element.on('destroy.modalmanager', targetIsSelf(function (e) {
+			modal.$element.on('destroy.modal.modalmanager', targetIsSelf(function (e) {
 				that.removeModal(modal);
 			}));
 
@@ -326,7 +326,7 @@
 
 				this.$spinner = $(this.createContainer())
 					.append($spinner)
-					.on('click.modalmanager', $.proxy(this.loading, this));
+					.on('click.modal.modalmanager', $.proxy(this.loading, this));
 
 				this.isLoading = true;
 


### PR DESCRIPTION
`event.namespace` for all events, to prevent any clashing, etc. 
See [#57](https://github.com/jschr/bootstrap-modal/issues/57)
