### PR TITLE
flexible height / maxHeight option

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -120,18 +120,12 @@
 				this.$element.css('margin-left', '');
 			}
 
-			if (value){
-				if (typeof value == 'function') value = $.proxy(value,this)();
-				if (value == 'auto') value = $(window).height() - 165 ;
+			if (typeof value == 'function') value = $.proxy(value,this)();
+			if (value == 'auto') value = $(window).height() - 165 ;
 
-				this.$element.find('.modal-body')
-					.css('overflow', 'auto')
-					.css(prop, value);
-			} else {
-				this.$element.find('.modal-body')
-					.css('overflow', '')
-					.css(prop, '');
-			}
+			this.$element.find('.modal-body')
+				.css('overflow', (value && 'auto') || '')
+				.css(prop, value || '');
 
 			var modalOverflow = $(window).height() - 10 < this.$element.height();
 


### PR DESCRIPTION
height and  maxHeight option can pass a callback function or string
'auto',
for recalculating height/maxHeight of modal-body  everytime window's
size changed.
1. with default maxHeight = null
   ![nserver-bootstrap-06](https://f.cloud.github.com/assets/822889/132508/ec2b736c-7086-11e2-91d1-051cf2a40d24.png)
2. with maxHeight = 'auto'
   ![nserver-bootstrap-07](https://f.cloud.github.com/assets/822889/132515/1347dfbc-7087-11e2-82df-25a136e5dc5d.png)
