### PR TITLE
Adding component.json for bower integration

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,15 @@
+{
+  "name": "bootstrap-modal",
+  "description": "Extends the default Bootstrap Modal class. Responsive, stackable, ajax and more.",
+  "version": "2.1",
+  "dependencies": {
+    "bootstrap": "2.3.0"
+  },
+  "url": "https://github.com/jschr/bootstrap-modal.git",
+  "author": "Jordan Schroter",
+  "license": {
+    "type": "Apache License 2.0",
+    "url": "https://github.com/jschr/bootstrap-modal/blob/master/LICENSE"
+  }
+
+}


### PR DESCRIPTION
I've added more properties than needed based on composer.json.

For now bower only use : 
- _name_
- _version_
- _dependencies_
- _main_: it seems that main can only use 1 js and 1 css. so I did not set this entry

See https://github.com/twitter/bower/issues/110 for component.json spec.
