### PR TITLE
fixing demo after github.io switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta http-equiv="X-UA-Compatible" content="chrome=1">
   <title>Bootstrap-modal by jschr</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-  <link href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet" />
-  <link href="http://twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.css" rel="stylesheet" />
+  <link href="http://twitter.github.io/bootstrap/assets/css/bootstrap.css" rel="stylesheet" />
+  <link href="http://twitter.github.io/bootstrap/assets/js/google-code-prettify/prettify.css" rel="stylesheet" />
 <style>
   body { 
     padding-top: 40px; 
   }
 </style>
-  <link href="http://twitter.github.com/bootstrap/assets/css/bootstrap-responsive.css" rel="stylesheet" />
+  <link href="http://twitter.github.io/bootstrap/assets/css/bootstrap-responsive.css" rel="stylesheet" />
   <link href="css/bootstrap-modal.css" rel="stylesheet" />
 <style>      
   .text-center { 
@@ -281,8 +281,8 @@
 
 <div id="ajax-modal" class="modal hide fade" tabindex="-1"></div>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
-    <script type="text/javascript" src="http://twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.js"></script>
-    <script src="http://twitter.github.com/bootstrap/assets/js/bootstrap.js"></script>
+    <script type="text/javascript" src="http://twitter.github.io/bootstrap/assets/js/google-code-prettify/prettify.js"></script>
+    <script src="http://twitter.github.io/bootstrap/assets/js/bootstrap.js"></script>
     <script src="js/bootstrap-modalmanager.js"></script>
     <script src="js/bootstrap-modal.js"></script>
 <script type="text/javascript">


### PR DESCRIPTION
All github pages now exist on github.io (originally github.com) which broke your links to twitter.github.com/boostrap assets.

link to announcement: https://github.com/blog/1452-new-github-pages-domain-github-io

I've just replaced all instances of "twitter.github.com" with "twitter.github.io" to fix the demo page
