### PR TITLE
rewrote tab function

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -152,7 +152,7 @@
 						var elements = [],
 							tabindex = Number($(this).data('tabindex'));
 
-						that.$element.find('[data-tabindex]:enabled:not([readonly])').each(function (ev) {
+						that.$element.find('[data-tabindex]:enabled:visible:not([readonly])').each(function (ev) {
 							elements.push(Number($(this).data('tabindex')));
 						});
 						elements.sort(function(a,b){return a-b});


### PR DESCRIPTION
old code doesn't work (for me) when I have more than two input.
in plus, in old code, "!e.shiftKey" doesn't work because point to the local "eventData" variable "e" and not to the "keydown eventData"
