### PR TITLE
Update bootstrap-modal.js to support scrollTop persistency over layout method calls

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -119,6 +119,8 @@
 				this.$element.css('width', '');
 				this.$element.css('margin-left', '');
 			}
+			
+			var scrollTop = this.$element.find('.modal-body').scrollTop();
 
 			this.$element.find('.modal-body')
 				.css('overflow', '')
@@ -129,6 +131,8 @@
 					.css('overflow', 'auto')
 					.css(prop, value);
 			}
+			
+			this.$element.find('.modal-body').scrollTop(scrollTop);
 
 			var modalOverflow = $(window).height() - 10 < this.$element.height();
             


### PR DESCRIPTION
We had a problem on our project that made the modal-body lose the scrollTop whenever we called the layout method on the modal to reload it's dimensions dynamically.

This proposed fix saves the current scrollTop value and redefine's it on the modal-body after the css changes done by the layout method.
