### PR TITLE
Add event on complete Ajax load

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -38,8 +38,10 @@
 			this.$element = $(element)
 				.delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this));
 
-			this.options.remote && this.$element.find('.modal-body').load(this.options.remote);
-
+			this.options.remote && this.$element.find('.modal-body').load(this.options.remote, function(){
+		      		var e = $.Event('ajax_onComplete.bs.modal', { relatedTarget: this })
+		      		$(element).trigger(e)
+		    	});
 			var manager = typeof this.options.manager === 'function' ?
 				this.options.manager.call(this) : this.options.manager;
 


### PR DESCRIPTION
Open more possibilities when you want to launch an operation at the end of the loading without adding complicated stuff

$(document).on('ajax_onComplete.bs.modal', function() {
    $('.modal').modal('layout');
});

Done !!

:)
