### PR TITLE
Update bootstrap-modal.js

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -16,7 +16,6 @@
  * limitations under the License.
  * ========================================================== */
 
-
 !function ($) {
 
 	"use strict"; // jshint ;_;
@@ -37,8 +36,7 @@
 
 			this.options = options;
 
-			this.$element = $(element)
-				.delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this));
+			this.$element = $(element);
 
 			this.options.remote && this.$element.find('.modal-body').load(this.options.remote, function () {
 				var e = $.Event('loaded');
@@ -80,6 +78,10 @@
 			e = $.Event('hide');
 
 			this.$element.trigger(e);
+
+			if (this.options.onHide !== null) {
+				eval(this.options.onHide);
+			}
 
 			if (!this.isShown || e.isDefaultPrevented()) return (this.isShown = false);
 
@@ -136,7 +138,7 @@
 			}
 
 			var modalOverflow = $(window).height() - 10 < this.$element.height();
-            
+
 			if (modalOverflow || this.options.modalOverflow) {
 				this.$element
 					.css('margin-top', 0)
@@ -153,13 +155,13 @@
 
 			if (this.isShown && this.options.consumeTab) {
 				this.$element.on('keydown.tabindex.modal', '[data-tabindex]', function (e) {
-			    	if (e.keyCode && e.keyCode == 9){
+					if (e.keyCode && e.keyCode == 9){
 						var $next = $(this),
 							$rollover = $(this);
 
 						that.$element.find('[data-tabindex]:enabled:not([readonly])').each(function (e) {
 							if (!e.shiftKey){
-						 		$next = $next.data('tabindex') < $(this).data('tabindex') ?
+								$next = $next.data('tabindex') < $(this).data('tabindex') ?
 									$next = $(this) :
 									$rollover = $(this);
 							} else {
@@ -185,11 +187,17 @@
 			if (this.isShown && this.options.keyboard) {
 				if (!this.$element.attr('tabindex')) this.$element.attr('tabindex', -1);
 
-				this.$element.on('keyup.dismiss.modal', function (e) {
-					e.which == 27 && that.hide();
-				});
+				this.$element
+					.on('keyup.dismiss.modal', function (e) {
+						if (e.which === 27) {
+							e.preventDefault();
+							e.stopPropagation();
+
+							that.hide();
+						}
+					});
 			} else if (!this.isShown) {
-				this.$element.off('keyup.dismiss.modal')
+				this.$element.off('keyup.dismiss.modal');
 			}
 		},
 
@@ -265,15 +273,15 @@
 		focus: function () {
 			var $focusElem = this.$element.find(this.options.focusOn);
 
-			$focusElem = $focusElem.length ? $focusElem : this.$element;
+			$focusElem = $focusElem.length > 0 ? $focusElem[0] : this.$element[0];
 
 			$focusElem.focus();
 		},
 
-		attention: function (){
+		attention: function () {
 			// NOTE: transitionEnd with keyframes causes odd behaviour
 
-			if (this.options.attentionAnimation){
+			if (this.options.attentionAnimation) {
 				this.$element
 					.removeClass('animated')
 					.removeClass(this.options.attentionAnimation);
@@ -286,7 +294,6 @@
 						.addClass(that.options.attentionAnimation);
 				}, 0);
 			}
-
 
 			this.focus();
 		},
@@ -346,6 +353,7 @@
 		modalOverflow: false,
 		consumeTab: true,
 		focusOn: null,
+		onHide : null,
 		replace: false,
 		resize: false,
 		attentionAnimation: 'shake',
@@ -361,19 +369,29 @@
 	* ============== */
 
 	$(function () {
-		$(document).off('click.modal').on('click.modal.data-api', '[data-toggle="modal"]', function ( e ) {
-			var $this = $(this),
-				href = $this.attr('href'),
-				$target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))), //strip for ie7
-				option = $target.data('modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data());
+		$(document)
+			.off('click.modal')
+			.on('click.modal.data-api', '[data-dismiss="modal"]', function ( e ) {
+				e.preventDefault();
 
-			e.preventDefault();
-			$target
-				.modal(option)
-				.one('hide', function () {
-					$this.focus();
-				})
-		});
+				$(this)
+					.parents(".modal:first")
+					.modal("hide");
+			})
+			.on('click.modal.data-api', '[data-toggle="modal"]', function ( e ) {
+				var $this = $(this),
+					href = $this.attr('href'),
+					$target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))), //strip for ie7
+					option = $target.data('modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data());
+
+				e.preventDefault();
+
+				$target
+					.modal(option)
+					.one('hide', function () {
+						$this.focus();
+					})
+			});
 	});
 
 }(window.jQuery);


### PR DESCRIPTION
Hello, I needed to run a JS function to close the modal, and to facilitate the use of this option, I did an implementation for the user to place the function in the data-on-hide. Follow my suggestion and would also be interesting to make the other events like show. Also implemented to use a modal inside the other, and each with a different form, and they are written in my own case within the form's. Not changed the default behavior of the script.
