### PR TITLE
call modal.destroy() in modalmanager destroyModal()

### DIFF
--- a/js/bootstrap-modalmanager.js
+++ b/js/bootstrap-modalmanager.js
@@ -164,6 +164,8 @@
 			if (modal.$backdrop) this.removeBackdrop(modal);
 			this.stack.splice(this.getIndexOfModal(modal), 1);
 
+			modal.destroy();
+
 			var hasOpenModal = this.hasOpenModal();
 
 			this.$element.toggleClass('modal-open', hasOpenModal);


### PR DESCRIPTION
I upgraded my copy of your library to the latest master version. I then found that when I opened and closed and then re-opened my modal without reloading the page, I wasn't receiving the .on('show') events that I had attached to the modal instance. After looking at the diff of changes, I noticed that modal.destroy() wasn't being called anymore. Adding that back fixed the issue for me.

See the screenshot of the diff that I'm talking about: http://take.ms/wzZmh
