### PR TITLE
Adding and refactoring methods that concern Loading feature.

### DIFF
--- a/js/bootstrap-modalmanager.js
+++ b/js/bootstrap-modalmanager.js
@@ -342,9 +342,10 @@
 				this.$backdropHandle = null;
 				this.removeSpinner();
 			}
+			var that = this;
 			$.support.transition && this.$backdropHandle ?
-				this.$backdropHandle.one($.support.transition.end, function () { remove.call(this); }) :
-				remove.call(this);
+				this.$backdropHandle.one($.support.transition.end, function () { remove.call(that); }) :
+				remove.call(that);
 		},
 
 		loading: function (callback) {


### PR DESCRIPTION
'removeLoading' method can be called multiple times on ModalManager. There's no need to verify if modal is actually open or if loading is active.
