### PR TITLE
Compute z-index where modals will be inserted

### DIFF
--- a/js/bootstrap-modalmanager.js
+++ b/js/bootstrap-modalmanager.js
@@ -363,8 +363,8 @@
 		return function (type, pos) {
 
 			if (typeof zIndexFactor === 'undefined'){
-				var $baseModal = $('<div class="modal hide" />').appendTo('body'),
-					$baseBackdrop = $('<div class="modal-backdrop hide" />').appendTo('body');
+				var $baseModal = $('<div class="modal hide" />').appendTo($.fn.modal.defaults.manager),
+					$baseBackdrop = $('<div class="modal-backdrop hide" />').appendTo($.fn.modal.defaults.manager);
 
 				baseIndex['modal'] = +$baseModal.css('z-index');
 				baseIndex['backdrop'] = +$baseBackdrop.css('z-index');


### PR DESCRIPTION
This change ensures that the z-index of both the modal and its backdrop are computed according to the same CSS rules that will apply once the actual elements are added to the DOM.

This in fact fixes modals for people who use a prefixed version of bootstrap:

```
$.fn.modal.defaults.manager = '.bootstrap-css';
```
