### PR TITLE
Fixed script error after closing modal when using x-editable

### DIFF
--- a/js/bootstrap-modalmanager.js
+++ b/js/bootstrap-modalmanager.js
@@ -385,7 +385,7 @@
 	// if Boostsrap namespaced events, this would not be needed.
 	function targetIsSelf(callback){
 		return function (e) {
-			if (this === e.target){
+			if (e && this === e.target){
 				return callback.apply(this, arguments);
 			}
 		}


### PR DESCRIPTION
Fixed a script error after closing a modal when using bootstrap-modal in combination with https://github.com/vitalets/x-editable.

X-editable uses jQuery.event.special.destroyed to implement a 'destroyed' event. This triggers the bootstrap-modal 'destroyed' event handler without the event parameter. See https://github.com/vitalets/x-editable/blob/master/dist/bootstrap-editable/js/bootstrap-editable.js#L1397

Solution: add a null check for the event parameter.

fixes #236
