### PR TITLE
Fix dependency conflict when using bootstrap 3 and bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "version": "2.2.5",
   "main": ["js/bootstrap-modal.js", "js/bootstrap-modalmanager.js", "css/bootstrap-modal.css"],
   "dependencies": {
-    "bootstrap": "2.3.0"
+    "bootstrap": ">2.3.0"
   },
   "url": "https://github.com/jschr/bootstrap-modal.git",
   "author": "Jordan Schroter",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "version": "2.2.5",
   "main": ["js/bootstrap-modal.js", "js/bootstrap-modalmanager.js", "css/bootstrap-modal.css"],
   "dependencies": {
-    "bootstrap": ">2.3.0"
+    "bootstrap": ">=2.3.0"
   },
   "url": "https://github.com/jschr/bootstrap-modal.git",
   "author": "Jordan Schroter",


### PR DESCRIPTION
Having the bower dependency to bootstrep fixed to the version ``2.3.0`` was causing conflict when we use bootstrap 3.